### PR TITLE
[CHORE] 애플로그인 시 백엔드에 보내야 하는 값 확인(#103)

### DIFF
--- a/FoodBowl/Screens/Sign/OnboardingViewController.swift
+++ b/FoodBowl/Screens/Sign/OnboardingViewController.swift
@@ -8,10 +8,13 @@
 import AuthenticationServices
 import UIKit
 
+import CryptoKit
 import SnapKit
 import Then
 
 final class OnboardingViewController: BaseViewController {
+    fileprivate var currentNonce: String?
+
     // MARK: - property
 
     private let appLogoView = UILabel().then {
@@ -72,11 +75,58 @@ final class OnboardingViewController: BaseViewController {
     private func appleSignIn() {
         let provider = ASAuthorizationAppleIDProvider()
         let request = provider.createRequest()
+        let nonce = randomNonceString()
+        currentNonce = nonce
         request.requestedScopes = [.fullName, .email]
+        request.nonce = sha256(nonce)
+        let _ = print(request.nonce ?? "")
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = self
         controller.presentationContextProvider = self
         controller.performRequests()
+    }
+
+    // String으로 nonce 생성
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: [Character] =
+            Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0 ..< 16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError(
+                        "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
+                    )
+                }
+                return random
+            }
+
+            randoms.forEach { random in
+                if remainingLength == 0 {
+                    return
+                }
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+        return result
+    }
+
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap {
+            String(format: "%02x", $0)
+        }.joined()
+
+        return hashString
     }
 }
 
@@ -96,10 +146,18 @@ extension OnboardingViewController: ASAuthorizationControllerDelegate {
                 switch credentialState {
                 case .authorized:
                     // The Apple ID credential is valid. Show Home UI Here
-//                    guard let token = appleIDCredential.identityToken else { return }
-//                    guard let tokenToString = String(data: token, encoding: .utf8) else { return }
+                    guard let token = appleIDCredential.identityToken else { return }
+                    guard let tokenToString = String(data: token, encoding: .utf8) else { return }
+                    guard let nonce = self.currentNonce else { return }
+
                     UserDefaultHandler.setIsLogin(isLogin: true)
                     DispatchQueue.main.async {
+                        let _ = print(Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String ?? "")
+                        let _ = print("------------")
+                        let _ = print(tokenToString)
+                        let _ = print("------------")
+                        let _ = print(nonce)
+                        let _ = print("------------")
                         let agreementViewController = AgreementViewController()
                         self.navigationController?.pushViewController(agreementViewController, animated: true)
                     }

--- a/FoodBowl/Screens/Sign/OnboardingViewController.swift
+++ b/FoodBowl/Screens/Sign/OnboardingViewController.swift
@@ -14,7 +14,6 @@ import Then
 
 final class OnboardingViewController: BaseViewController {
     fileprivate var currentNonce: String?
-
     // MARK: - property
 
     private let appLogoView = UILabel().then {
@@ -75,48 +74,18 @@ final class OnboardingViewController: BaseViewController {
     private func appleSignIn() {
         let provider = ASAuthorizationAppleIDProvider()
         let request = provider.createRequest()
-        let nonce = randomNonceString()
+        let nonce = "wH_pSu5wSUHzoFPBUE9Q9ZRs3fcKzGSn"
         currentNonce = nonce
         request.requestedScopes = [.fullName, .email]
         request.nonce = sha256(nonce)
+        let _ = print("------------")
+        let _ = print("암호화 된 nonce값")
         let _ = print(request.nonce ?? "")
+        let _ = print("------------")
         let controller = ASAuthorizationController(authorizationRequests: [request])
         controller.delegate = self
         controller.presentationContextProvider = self
         controller.performRequests()
-    }
-
-    // String으로 nonce 생성
-    private func randomNonceString(length: Int = 32) -> String {
-        precondition(length > 0)
-        let charset: [Character] =
-            Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
-        var result = ""
-        var remainingLength = length
-
-        while remainingLength > 0 {
-            let randoms: [UInt8] = (0 ..< 16).map { _ in
-                var random: UInt8 = 0
-                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
-                if errorCode != errSecSuccess {
-                    fatalError(
-                        "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
-                    )
-                }
-                return random
-            }
-
-            randoms.forEach { random in
-                if remainingLength == 0 {
-                    return
-                }
-                if random < charset.count {
-                    result.append(charset[Int(random)])
-                    remainingLength -= 1
-                }
-            }
-        }
-        return result
     }
 
     private func sha256(_ input: String) -> String {
@@ -152,10 +121,13 @@ extension OnboardingViewController: ASAuthorizationControllerDelegate {
 
                     UserDefaultHandler.setIsLogin(isLogin: true)
                     DispatchQueue.main.async {
+                        let _ = print("번들ID값")
                         let _ = print(Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String ?? "")
                         let _ = print("------------")
+                        let _ = print("토큰 값")
                         let _ = print(tokenToString)
                         let _ = print("------------")
+                        let _ = print("암호화 되지 않은 nonce값")
                         let _ = print(nonce)
                         let _ = print("------------")
                         let agreementViewController = AgreementViewController()


### PR DESCRIPTION
## 🌁 Background
<!-- 해당 PR을 작성하게 된 이유를 적어주세요. -->
백엔드와 애플로그인 연결을 위해 값들을 넘겨줍니다.

## 👩‍💻 Contents
<!-- 작업 내용을 적어주세요 -->
애플 로그인 완료 후 백엔드에 필요한 값들을 서버 연결 전에 print문으로 확인하는 과정입니다.

## ✅ Testing
<!-- 테스트 방법을 적어주세요 -->
로그인 시 log에 뜨도록 되어있습니다.

## 📱 Screenshot
<!-- 스크린샷이나 동영상을 첨부해주세요. -->

![스크린샷 2023-08-09 오후 7 25 12](https://github.com/Busan-Dinosaur/FoodBowl-iOS/assets/81131715/3a19bf65-42f5-44f1-9135-4d80fbd5ea25)

## 📝 Review Note
<!-- PR과정에서 든 생각이나 개선할 내용이 있다면 적어주세요. -->

1. 스크린 샷에서 맨 위 출력값이 request시 nonce값
2. 번들 id값
3. token값
4. nonce값입니다.

1번 값과 4번 값은 nonce값이 형성되어야 한다고 생각중인데, 같지 않아서 고민중입니다.
의견주시면 감사합니다.
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #103


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
https://velog.io/@sun02/Swift%EC%97%90%EC%84%9C-SHA-256-%ED%95%B4%EC%8B%9C%EA%B0%92-%EA%B5%AC%ED%95%98%EA%B8%B0